### PR TITLE
Add FastAPI DICOMweb proxy

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+DICOMWEB_URL=http://dicom.example.com
+DICOMWEB_USER=
+DICOMWEB_PASS=
+LOG_FILE=app.log
+OTEL_TRACE_FILE=app-otel.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+# Create non-root user
+RUN useradd -m appuser
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN chown -R appuser:appuser /app
+USER appuser
+
+ENV DICOMWEB_URL="" \
+    DICOMWEB_USER="" \
+    DICOMWEB_PASS=""
+
+HEALTHCHECK CMD curl --fail http://localhost:8000/health || exit 1
+
+CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# nesttest
-vibecoding
+# DICOMweb Proxy
+
+This project provides a FastAPI based proxy for a DICOMweb server. It exposes simple endpoints to list patients, retrieve instances and render images.
+
+## Setup
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Create a `.env` file with:
+
+```
+DICOMWEB_URL=http://your.dicom.server
+DICOMWEB_USER=user
+DICOMWEB_PASS=pass
+```
+
+## Run Locally
+
+```bash
+uvicorn main:app --reload
+```
+
+## Docker
+
+Build and run the container:
+
+```bash
+docker build -t dicomweb-proxy .
+docker run -p 8000:8000 dicomweb-proxy
+```
+
+## Tests
+
+Run unit tests:
+
+```bash
+pytest
+```
+
+Run BDD tests (requires Docker):
+
+```bash
+behave
+```
+

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,9 @@
+"""API package."""
+
+from fastapi import APIRouter
+
+from . import patients
+
+router = APIRouter()
+router.include_router(patients.router)
+

--- a/api/patients.py
+++ b/api/patients.py
@@ -1,0 +1,48 @@
+"""API routes for patient operations."""
+
+from fastapi import APIRouter, HTTPException
+
+from ..services.dicom_client import get_dicom_client
+from ..services.renderer import get_rendered_image
+
+router = APIRouter()
+
+
+@router.get("/patients")
+def list_patients():
+    """List unique patients from studies."""
+    client = get_dicom_client()
+    studies = client.search_for_studies()
+
+    patients = {}
+    for study in studies:
+        pid = study.get("00100020")  # PatientID
+        if not pid:
+            continue
+        if pid not in patients:
+            patients[pid] = {
+                "id": pid,
+                "name": study.get("00100010"),
+                "age": study.get("00101010"),
+            }
+    return list(patients.values())
+
+
+@router.get("/patients/{patient_id}/instances")
+def list_instances(patient_id: str):
+    """Return SOP Instance UIDs for a patient."""
+    client = get_dicom_client()
+    instances = client.search_for_instances({"PatientID": patient_id})
+
+    uids = [inst.get("00080018") for inst in instances]
+    return [uid for uid in uids if uid]
+
+
+@router.get("/patients/{patient_id}/instances/{sop_id}/render")
+def render_instance(patient_id: str, sop_id: str):
+    """Return rendered PNG bytes for an instance."""
+    image = get_rendered_image(patient_id, sop_id)
+    if not image:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return image
+

--- a/features/patients.feature
+++ b/features/patients.feature
@@ -1,0 +1,6 @@
+Feature: Patients API
+  Scenario: List patients
+    Given the dicomweb proxy is running in Docker
+    When I request "/patients"
+    Then the response code should be 200
+

--- a/features/steps/__init__.py
+++ b/features/steps/__init__.py
@@ -1,0 +1,2 @@
+# Steps package
+

--- a/features/steps/patients_steps.py
+++ b/features/steps/patients_steps.py
@@ -1,0 +1,35 @@
+from behave import given, when, then
+import requests
+import subprocess
+import time
+
+CONTAINER_NAME = "dicomweb-proxy-test"
+
+
+def start_container():
+    subprocess.run(["docker", "build", "-t", CONTAINER_NAME, "."], check=True)
+    proc = subprocess.Popen(["docker", "run", "-d", "-p", "8000:8000", "--name", CONTAINER_NAME, CONTAINER_NAME])
+    time.sleep(5)
+    return proc
+
+
+def stop_container():
+    subprocess.run(["docker", "stop", CONTAINER_NAME], check=False)
+    subprocess.run(["docker", "rm", CONTAINER_NAME], check=False)
+
+
+@given("the dicomweb proxy is running in Docker")
+def given_running_proxy(context):
+    context.proc = start_container()
+
+
+@when('I request "{path}"')
+def when_request(context, path):
+    context.response = requests.get(f"http://localhost:8000{path}")
+
+
+@then("the response code should be 200")
+def then_status(context):
+    assert context.response.status_code == 200
+    stop_container()
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,123 @@
+"""Entry point for the FastAPI DICOMweb proxy."""
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import PlainTextResponse
+from uvicorn import run
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider, ReadableSpan
+from opentelemetry.sdk.trace.export import (
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+from api import patients
+from services.dicom_client import get_settings
+
+import json
+from typing import Iterable
+
+
+class FileSpanExporter(SpanExporter):
+    """Custom span exporter writing spans to a file."""
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+        self._file = open(file_path, "a")
+
+    def export(self, spans: Iterable[ReadableSpan]) -> SpanExportResult:
+        for span in spans:
+            ctx = span.get_span_context()
+            data = {
+                "name": span.name,
+                "trace_id": format(ctx.trace_id, "032x"),
+                "span_id": format(ctx.span_id, "016x"),
+                "start": span.start_time,
+                "end": span.end_time,
+                "status": span.status.status_code.name,
+            }
+            self._file.write(json.dumps(data) + "\n")
+        self._file.flush()
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        self._file.close()
+
+
+def configure_logging() -> None:
+    """Configure application logging."""
+    log_file = os.getenv("LOG_FILE", "app.log")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
+    handlers = [logging.StreamHandler()]
+    file_handler = RotatingFileHandler(log_file, maxBytes=1024 * 1024, backupCount=3)
+    handlers.append(file_handler)
+
+    for handler in handlers:
+        handler.setFormatter(formatter)
+
+    logging.basicConfig(level=logging.INFO, handlers=handlers)
+
+
+def configure_tracing() -> None:
+    """Set up OpenTelemetry tracing exporters."""
+    resource = Resource.create({"service.name": "dicomweb-proxy"})
+    provider = TracerProvider(resource=resource)
+
+    # Console exporter
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+    # File exporter
+    otel_file = os.getenv("OTEL_TRACE_FILE", "app-otel.log")
+    provider.add_span_processor(SimpleSpanProcessor(FileSpanExporter(otel_file)))
+
+    # Optional OTLP exporter
+    otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if otlp_endpoint and otlp_endpoint.startswith(("http://", "https://")):
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+        provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint)))
+
+    trace.set_tracer_provider(provider)
+
+
+def create_app() -> FastAPI:
+    """Create and configure FastAPI app."""
+    configure_logging()
+    configure_tracing()
+
+    app = FastAPI()
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/health", response_class=PlainTextResponse)
+    def health() -> str:
+        return "ok"
+
+    app.include_router(patients.router)
+    FastAPIInstrumentor.instrument_app(app)
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    settings = get_settings()
+    run("main:app", host="0.0.0.0", port=8000, reload=False)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+fastapi
+uvicorn[standard]
+dicomweb-client
+python-dotenv
+pydantic
+pydantic-settings
+requests
+pillow
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-instrumentation-fastapi
+opentelemetry-exporter-otlp
+pytest
+pytest-asyncio
+httpx
+behave
+

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,2 @@
+"""Services package."""
+

--- a/services/dicom_client.py
+++ b/services/dicom_client.py
@@ -1,0 +1,40 @@
+"""Utility to initialize and provide a DICOMwebClient instance."""
+
+from functools import lru_cache
+from typing import Optional
+
+from requests.auth import HTTPBasicAuth
+from dicomweb_client.api import DICOMwebClient
+from dicomweb_client.session_utils import create_session_from_auth
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment."""
+
+    DICOMWEB_URL: str
+    DICOMWEB_USER: Optional[str] = None
+    DICOMWEB_PASS: Optional[str] = None
+
+    class Config:
+        env_file = ".env"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached settings instance."""
+    return Settings()
+
+
+@lru_cache()
+def get_dicom_client() -> DICOMwebClient:
+    """Construct and cache a DICOMwebClient with basic auth."""
+    settings = get_settings()
+    auth = None
+    if settings.DICOMWEB_USER and settings.DICOMWEB_PASS:
+        auth = HTTPBasicAuth(settings.DICOMWEB_USER, settings.DICOMWEB_PASS)
+    session = create_session_from_auth(auth) if auth else None
+    client = DICOMwebClient(url=settings.DICOMWEB_URL, session=session)
+    return client
+

--- a/services/renderer.py
+++ b/services/renderer.py
@@ -1,0 +1,30 @@
+"""Renderer service for retrieving rendered DICOM instances."""
+
+from typing import Tuple
+
+from fastapi import HTTPException
+
+from .dicom_client import get_dicom_client
+
+
+def get_rendered_image(patient_id: str, sop_instance_uid: str) -> bytes:
+    """Retrieve rendered PNG for given SOP Instance UID."""
+    client = get_dicom_client()
+
+    # Find instance to obtain study and series UIDs
+    instances = client.search_for_instances({"PatientID": patient_id, "SOPInstanceUID": sop_instance_uid})
+    if not instances:
+        raise HTTPException(status_code=404, detail="Instance not found")
+
+    instance = instances[0]
+    study_uid = instance.get("0020000D")  # StudyInstanceUID
+    series_uid = instance.get("0020000E")  # SeriesInstanceUID
+
+    rendered = client.retrieve_instance_rendered(
+        study_instance_uid=study_uid,
+        series_instance_uid=series_uid,
+        sop_instance_uid=sop_instance_uid,
+        media_types=("image/png",),
+    )
+    return rendered
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Test package
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,56 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_client():
+    with patch("services.dicom_client.get_dicom_client") as mock:
+        yield mock
+
+
+def test_list_patients(mock_client):
+    mock_instance = MagicMock()
+    mock_instance.search_for_studies.return_value = [
+        {"00100020": "P1", "00100010": "John", "00101010": "030Y"},
+        {"00100020": "P2", "00100010": "Alice", "00101010": "025Y"},
+    ]
+    mock_client.return_value = mock_instance
+
+    response = client.get("/patients")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"id": "P1", "name": "John", "age": "030Y"},
+        {"id": "P2", "name": "Alice", "age": "025Y"},
+    ]
+
+
+def test_list_instances(mock_client):
+    mock_instance = MagicMock()
+    mock_instance.search_for_instances.return_value = [
+        {"00080018": "1"},
+        {"00080018": "2"},
+    ]
+    mock_client.return_value = mock_instance
+
+    response = client.get("/patients/P1/instances")
+    assert response.status_code == 200
+    assert response.json() == ["1", "2"]
+
+
+def test_render_instance(mock_client):
+    mock_instance = MagicMock()
+    mock_instance.search_for_instances.return_value = [
+        {"0020000D": "study1", "0020000E": "series1"}
+    ]
+    mock_instance.retrieve_instance_rendered.return_value = b"data"
+    mock_client.return_value = mock_instance
+
+    response = client.get("/patients/P1/instances/1/render")
+    assert response.status_code == 200
+    assert response.content == b"data"
+


### PR DESCRIPTION
## Summary
- implement FastAPI DICOMweb proxy with logging and OpenTelemetry
- add DICOMweb client and renderer services
- provide patients API routes
- include Dockerfile, requirements and tests
- document setup and usage

## Testing
- `python -m py_compile $(ls **/*.py)`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68480a93df9c8331acddad4495c944d0